### PR TITLE
Fix start game button visibility after reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -1090,6 +1090,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Show Start Game and Rules buttons
         showElement(canvasOverlay, 'flex'); // Show the Start Game overlay
+        showElement(startGameButton, 'inline-block'); // Ensure the Start Game button is visible
         showElement(rulesButton, 'block');
 
         // Reset overlay content
@@ -1281,6 +1282,7 @@ document.addEventListener('DOMContentLoaded', () => {
             currentLevelDisplay.textContent = level;
             leaderboardLevelDisplay.textContent = level;
             showElement(canvasOverlay, 'flex'); // Show the Start Game overlay
+            showElement(startGameButton, 'inline-block'); // Ensure the Start Game button is visible
         }
 
         console.log(`Skipping to Level ${level}.`);


### PR DESCRIPTION
## Summary
- ensure resetGame shows the start button
- ensure skipping to a level also shows the start button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68512055406c83268e07df9af280da48