### PR TITLE
Fix final scoreboard column order and time display

### DIFF
--- a/script.js
+++ b/script.js
@@ -756,7 +756,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const thead = document.createElement('thead');
             const headerRow = document.createElement('tr');
-            ['Level', 'Name', 'Score', 'Clicks', 'Time (s)', 'Missed Clicks'].forEach((text) => {
+            ['Level', 'Name', 'Time (s)', 'Clicks', 'Missed Clicks', 'Score'].forEach((text) => {
                 const th = document.createElement('th');
                 th.textContent = text;
                 // Style the header cells
@@ -789,7 +789,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 row.appendChild(nameCell);
 
                 const timeCell = document.createElement('td');
-                timeCell.textContent = `${entry.time}s`;
+                timeCell.textContent = entry.time === 'N/A' ? 'N/A' : `${entry.time}s`;
                 timeCell.style.border = '1px solid #ccc';
                 timeCell.style.padding = '6px 8px';
                 row.appendChild(timeCell);


### PR DESCRIPTION
### Motivation

- The final scoreboard table headers were misaligned with the row data, causing columns to display incorrect values under the wrong headings.  
- Time values that were missing were being rendered with a suffix or inconsistent representation instead of a clear `N/A`.  

### Description

- Reordered the summary table header array to `['Level', 'Name', 'Time (s)', 'Clicks', 'Missed Clicks', 'Score']` so headers match the row cell order.  
- Adjusted the time cell rendering to set `timeCell.textContent` to `entry.time === 'N/A' ? 'N/A' : `${entry.time}s`` to avoid appending `s` to missing values.  
- Left the existing `getTopScoresPerLevel()` usage unchanged while fixing presentation issues in the final scoreboard.  

### Testing

- A Playwright evaluation initially failed with a `TypeError` when the overlay content node was missing.  
- A subsequent Playwright run timed out when trying to interact with the page.  
- The final Playwright script completed successfully and produced a screenshot artifact at `artifacts/summary-table.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960345007b083268925fef4445b3006)